### PR TITLE
Order management & documentation for index of tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,33 @@ $ npm install hexo-generator-tag --save
 ``` yaml
 tag_generator:
   per_page: 10
+  enable_index_page: false
 ```
 
 - **per_page**: Posts displayed per page. (0 = disable pagination)
+- **enable_index_page**: defines whether an index page is generated. (0 = disable pagination)
+
+## Index page generation
+
+If `enable_index_page` is set to true, the Hexo generator tag will serch for a template named "tag-index" to produce a webpage.
+
+The variable inserted into the template `tag-index` respect the structure :
+
+```
+{
+	base: tagDir,
+	total: 1,
+	current: 1,
+	current_url: tagDir,
+	posts: locals.posts, // all posts
+	prev: 0,
+	prev_link: '',
+	next: 0,
+	next_link: '',
+	tags: tags // all tags
+ }
+ ```
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,16 @@ $ npm install hexo-generator-tag --save
 
 ``` yaml
 tag_generator:
-  per_page: 10
-  enable_index_page: false
+	per_page: 10
+	enable_index_page: false
+	orderby: name
+	order: 1
 ```
 
 - **per_page**: Posts displayed per page. (0 = disable pagination)
-- **enable_index_page**: defines whether an index page is generated. (0 = disable pagination)
+- **enable_index_page**: defines whether an index page is generated.
+- **orderby**: Order of tags.
+- **order**: Sort order. 1, for ascending; -1, for descending
 
 ## Index page generation
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -6,8 +6,17 @@ module.exports = function(locals){
   var config = this.config;
   var perPage = config.tag_generator.per_page;
   var paginationDir = config.pagination_dir || 'page';
+  var orderby = config.tag_generator.orderby || 'name';
+  var order = config.tag_generator.order || 1;
   var tags = locals.tags;
   var tagDir;
+
+  // Sort the tags
+  if (orderby === 'random' || orderby === 'rand'){
+    tags = tags.random();
+  } else {
+    tags = tags.sort(orderby, order);
+  }
 
   var pages = tags.reduce(function(result, tag){
     if (!tag.length) return result;


### PR DESCRIPTION
- Documentation for index of tags (generated through https://github.com/hexojs/hexo-generator-tag/pull/2, thanks to @creeperyang)
- Adding order and orderby option, inspired by the tagCloud helper