### PR TITLE
test(index): run hexo.init beforAll hook & update TravisCI support node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,10 @@ cache:
     - node_modules
 
 node_js:
-  - "0.12"
-  - "4"
-  - "5"
+  - "6"
+  - "8"
+  - "10"
+  - "node"
 
 script:
   - npm run eslint

--- a/test/index.js
+++ b/test/index.js
@@ -5,6 +5,7 @@ var Hexo = require('hexo');
 
 describe('Tag generator', function() {
   var hexo = new Hexo(__dirname, {silent: true});
+  hexo.init();
   var Post = hexo.model('Post');
   var generator = require('../lib/generator').bind(hexo);
   var posts;


### PR DESCRIPTION
## Proposal

Add run `hexo.init` beforAll hooks

## Reason

Test are failed like belows, if `hexo.init` are not exists.

```
  Tag generator
    1) "before all" hook


  0 passing (22ms)
  1 failing

  1) Tag generator
       "before all" hook:
     TypeError: self.url_for is not a function
```