### PR TITLE
refactor(package): use Object.assign instead of object-assign package

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,7 @@
 /* global hexo */
 'use strict';
 
-var assign = require('object-assign');
-
-hexo.config.tag_generator = assign({
+hexo.config.tag_generator = Object.assign({
   per_page: hexo.config.per_page == null ? 10 : hexo.config.per_page
 }, hexo.config.tag_generator);
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "eslint-config-hexo": "^3.0.0"
   },
   "dependencies": {
-    "hexo-pagination": "0.1.0",
-    "object-assign": "^4.0.1"
+    "hexo-pagination": "0.1.0"
   }
 }


### PR DESCRIPTION
## Proposal

Use Object.assign instead of object-assign package

## Reason

Node.js 4 and up can be use Object.assign() instead of object-assign npm package.
This repository is already set node engine higher than 6.9.0 .
So, it can use Object.assign() .