### PR TITLE
added "explicit_paging" and "overwrite_latest" options

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,18 @@ $ npm install hexo-generator-tag --save
 tag_generator:
   per_page: 10
   order_by: -date
+  explicit_paging: false
+  overwrite_latest: false
+  verbose: false
 ```
 
 - **per_page**: Posts displayed per page. (0 = disable pagination)
 - **order_by**: Posts order. (Order by date descending by default)
 - **enable_index_page**: Generate a `/[config.tag_dir]/index.html` page.
   - Support following template layout: `tag-index`, `tag`, `archive`, `index`
+- **explicit_paging**: Explicit paging. (Number the first page. e.g. `page/1/index.html`)
+- **overwrite_latest**: Set the latest page. (`latest/index.html` in place of `page/N/index.html`)
+- **verbose**: verbose output. (Output all generated routes)
 
 ## License
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -18,10 +18,22 @@ module.exports = function(locals) {
       perPage: perPage,
       layout: ['tag', 'archive', 'index'],
       format: paginationDir + '/%d/',
+      explicitPaging: (config.tag_generator.explicit_paging || config.tag_generator.overwrite_latest || false),
       data: {
         tag: tag.name
       }
     });
+
+    if ((config.tag_generator.overwrite_latest || false) && data.length > 0) {
+      const lastPage = data[data.length - 1];
+      lastPage.path = lastPage.path.replace(/\/page\/\d+\/?$/, '/latest/');
+    }
+
+    if (config.tag_generator.verbose || false) {
+      data.forEach(page => {
+        console.log(`Generated tag route: ${page.path}`);
+      });
+    }
 
     return result.concat(data);
   }, []);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-generator-tag",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Tag generator for Hexo.",
   "main": "index",
   "scripts": {
@@ -33,7 +33,7 @@
     "mocha": "^10.0.0"
   },
   "dependencies": {
-    "hexo-pagination": "3.0.0"
+    "hexo-pagination": "4.0.0"
   },
   "engines": {
     "node": ">=14"


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo!
-->

## check list

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.

## Description

Adding a flag for `explicitPaging` introduced in the version 4.0.0 of hexo-pagination.
Adding the option to have the last page to be `latest` which is convenient in case of reverse pagination.

## Additional information
